### PR TITLE
add support for user CSS

### DIFF
--- a/Browsingway.Common/RenderProcess.cs
+++ b/Browsingway.Common/RenderProcess.cs
@@ -63,6 +63,7 @@ public class NewInlayRequest : DownstreamIpcRequest
 	public int Width;
 	public float Zoom;
 	public bool Muted;
+	public string CustomCss = null!;
 }
 
 [Serializable]
@@ -96,6 +97,13 @@ public class NavigateInlayRequest : DownstreamIpcRequest
 {
 	public Guid Guid;
 	public string Url = null!;
+}
+
+[Serializable]
+public class InjectUserCssRequest : DownstreamIpcRequest
+{
+	public Guid Guid;
+	public string Css = null!;
 }
 
 [Serializable]

--- a/Browsingway.Renderer/Program.cs
+++ b/Browsingway.Renderer/Program.cs
@@ -174,6 +174,13 @@ internal static class Program
 						return null;
 					}
 
+				case InjectUserCssRequest injectUserCssRequest:
+					{
+						Inlay inlay = _inlays[injectUserCssRequest.Guid];
+						inlay.InjectUserCss(injectUserCssRequest.Css);
+						return null;
+					}
+
 				default:
 					throw new Exception($"Unknown IPC request type {request?.GetType().Name} received.");
 			}
@@ -196,7 +203,7 @@ internal static class Program
 			_inlays.Remove(request.Guid);
 		}
 
-		Inlay inlay = new(request.Id, request.Url, request.Zoom, request.Muted, request.Framerate, renderHandler);
+		Inlay inlay = new(request.Id, request.Url, request.Zoom, request.Muted, request.Framerate, request.CustomCss, renderHandler);
 		inlay.Initialise();
 		_inlays.Add(request.Guid, inlay);
 
@@ -212,8 +219,15 @@ internal static class Program
 	{
 		return renderHandler switch
 		{
-			TextureRenderHandler textureRenderHandler => new TextureHandleResponse { TextureHandle = textureRenderHandler.SharedTextureHandle },
-			BitmapBufferRenderHandler bitmapBufferRenderHandler => new BitmapBufferResponse { BitmapBufferName = bitmapBufferRenderHandler.BitmapBufferName!, FrameInfoBufferName = bitmapBufferRenderHandler.FrameInfoBufferName },
+			TextureRenderHandler textureRenderHandler => new TextureHandleResponse
+			{
+				TextureHandle = textureRenderHandler.SharedTextureHandle
+			},
+			BitmapBufferRenderHandler bitmapBufferRenderHandler => new BitmapBufferResponse
+			{
+				BitmapBufferName = bitmapBufferRenderHandler.BitmapBufferName!,
+				FrameInfoBufferName = bitmapBufferRenderHandler.FrameInfoBufferName
+			},
 			_ => throw new Exception($"Unhandled render handler type {renderHandler.GetType().Name}")
 		};
 	}

--- a/Browsingway/Configuration.cs
+++ b/Browsingway/Configuration.cs
@@ -25,6 +25,7 @@ internal class InlayConfiguration
 	public string Url = null!;
 	public float Zoom = 100f;
 	public bool Disabled;
+	public string CustomCss = "";
 	public bool Muted;
 	public bool ActOptimizations;
 }

--- a/Browsingway/Inlay.cs
+++ b/Browsingway/Inlay.cs
@@ -49,6 +49,11 @@ internal class Inlay : IDisposable
 		_renderProcess.Send(new NavigateInlayRequest { Guid = RenderGuid, Url = newUrl });
 	}
 
+	public void InjectUserCss(string css)
+	{
+		_renderProcess.Send(new InjectUserCssRequest { Guid = RenderGuid, Css = css });
+	}
+
 	public void Zoom(float zoom)
 	{
 		_renderProcess.Send(new ZoomInlayRequest { Guid = RenderGuid, Zoom = zoom });
@@ -285,7 +290,8 @@ internal class Inlay : IDisposable
 				Height = (int)currentSize.Y,
 				Zoom = _inlayConfig.Zoom,
 				Framerate = _inlayConfig.Framerate,
-				Muted = _inlayConfig.Muted
+				Muted = _inlayConfig.Muted,
+				CustomCss = _inlayConfig.CustomCss
 			}
 			: new ResizeInlayRequest { Guid = RenderGuid, Width = (int)currentSize.X, Height = (int)currentSize.Y };
 

--- a/Browsingway/Plugin.cs
+++ b/Browsingway/Plugin.cs
@@ -105,6 +105,7 @@ public class Plugin : IDalamudPlugin
 			_settings.InlayMuted += OnInlayMuted;
 			_settings.TransportChanged += OnTransportChanged;
 			_actHandler.AvailabilityChanged += OnActAvailabilityChanged;
+			_settings.InlayUserCssChanged += OnUserCssChanged;
 		}
 
 		// Hook up the main BW command
@@ -175,6 +176,12 @@ public class Plugin : IDalamudPlugin
 		{
 			inlay.InvalidateTransport();
 		}
+	}
+
+	private void OnUserCssChanged(object? sender, InlayConfiguration config)
+	{
+		Inlay inlay = _inlays[config.Guid];
+		inlay.InjectUserCss(config.CustomCss);
 	}
 
 	private object? HandleIpcRequest(object? sender, UpstreamIpcRequest request)

--- a/Browsingway/Settings.cs
+++ b/Browsingway/Settings.cs
@@ -18,6 +18,8 @@ internal class Settings : IDisposable
 	public event EventHandler<InlayConfiguration>? InlayRemoved;
 	public event EventHandler<InlayConfiguration>? InlayZoomed;
 	public event EventHandler<InlayConfiguration>? InlayMuted;
+
+	public event EventHandler<InlayConfiguration>? InlayUserCssChanged;
 	public event EventHandler? TransportChanged;
 
 	public readonly Configuration Config;
@@ -212,6 +214,11 @@ internal class Settings : IDisposable
 	private void UpdateMuteInlay(InlayConfiguration inlayConfig)
 	{
 		InlayMuted?.Invoke(this, inlayConfig);
+	}
+
+	private void UpdateUserCss(InlayConfiguration inlayConfig)
+	{
+		InlayUserCssChanged?.Invoke(this, inlayConfig);
 	}
 
 	private void ReloadInlay(InlayConfiguration inlayConfig) { NavigateInlay(inlayConfig); }
@@ -566,6 +573,14 @@ internal class Settings : IDisposable
 		ImGui.NextColumn();
 
 		ImGui.Columns(1);
+
+		ImGui.Text("Custom CSS code:");
+		if (ImGui.InputTextMultiline("Custom CSS code", ref inlayConfig.CustomCss, 1000000,
+			    new Vector2(-1, ImGui.GetTextLineHeight() * 10)))
+		{
+			dirty = true;
+		}
+		if (ImGui.IsItemDeactivatedAfterEdit()) { UpdateUserCss(inlayConfig); }
 
 		if (ImGui.Button("Reload")) { ReloadInlay(inlayConfig); }
 


### PR DESCRIPTION
User CSS is great, and I wanted to use it in overlays just like we can with OBS overlays!

# Why ?

Here is my initial problem : I wanted to have the hunt discord in an overlay, so I used the discord streamkit overlay. It works... but it sucks (the one integrated in the "real" discord overlay sucks too!).

![image](https://user-images.githubusercontent.com/2473314/149148302-e8c3852e-81ec-4700-871c-3e940fdc223e.png)

*yummy big black box*

With custom css though I just have to add this code :
```css
.channel-name { display: none; }
.messages { 
  background-color: transparent!important;
  padding: 0!important;
  width: 100%!important;
  height: 100%!important;
}
.message-text { color: white!important; }
.timestamp {opacity: 1!important;color: white!important;} 
.chat-container { width: 100%!important; }
```

And **poof** :
![image](https://user-images.githubusercontent.com/2473314/149148533-b564e829-c7ba-41a5-b6bf-3e001b6e7d97.png)

Way better.

# Implementation

There is not much to say. I inject the inlay css when the frame gets loaded, then everytime the user has changed the User CSS field. I tried to understand the whole project logic and I think I did it properly.

The actual injection code is in `Browsingway.Renderer\Inlay.cs`, line 76.

Config looks like this: 

![image](https://user-images.githubusercontent.com/2473314/149149674-f1f7a191-2f12-44f8-a0ff-7c8568147104.png)

**Some notes:**

- there is no associated command as changing the css from the text chat is, imo a very bad idea


Feel free to ask anything and tell me if I did something wrong / dubious!

(you can also @ Xorus on the goat place plugin-dev discord)