### PR TITLE
Update RenderProcess.cs

### DIFF
--- a/Browsingway/RenderProcess.cs
+++ b/Browsingway/RenderProcess.cs
@@ -185,8 +185,9 @@ internal class RenderProcess : IDisposable
 			RedirectStandardError = true
 		};
 		string runtimePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "XIVLauncher", "runtime");
-		if (!process.StartInfo.EnvironmentVariables.ContainsKey("DOTNET_ROOT"))
-			process.StartInfo.EnvironmentVariables.Add("DOTNET_ROOT", runtimePath);
+		// ensure Dalamud's runtime is used even if there's a system runtime, to avoid runtime version mismatches
+		process.StartInfo.EnvironmentVariables.Remove("DOTNET_ROOT");
+		process.StartInfo.EnvironmentVariables.Add("DOTNET_ROOT", runtimePath);
 
 		process.OutputDataReceived += (_, args) => PluginLog.Log($"[Render]: {args.Data}");
 		process.ErrorDataReceived += (_, args) => PluginLog.LogError($"[Render]: {args.Data}");


### PR DESCRIPTION
Always override DOTNET_ROOT instead of deferring to a preexisting value. Avoids a crash if the system runtime is too new compared to Dalamud's.

![image](https://user-images.githubusercontent.com/73085/205055785-62a1915b-6072-471f-be37-2af534c76b53.png)
