### PR TITLE
Added a "Fullscreen" feature to inlays.

### DIFF
--- a/Browsingway.Renderer/RenderHandlers/TextureRenderHandler.cs
+++ b/Browsingway.Renderer/RenderHandlers/TextureRenderHandler.cs
@@ -90,8 +90,9 @@ internal class TextureRenderHandler : BaseRenderHandler
 			                        + (Math.Min(Math.Max(y, 0), _alphaLookupBufferHeight - 1) * rowPitch)
 			                        + 3;
 
-			if (cursorAlphaOffset < _alphaLookupBuffer.Length)
+			if (_alphaLookupBuffer.Length > 0 && cursorAlphaOffset < _alphaLookupBuffer.Length)
 				return _alphaLookupBuffer[cursorAlphaOffset];
+			
 			Console.WriteLine("Could not determine alpha value");
 			return 255;
 		}

--- a/Browsingway/Configuration.cs
+++ b/Browsingway/Configuration.cs
@@ -28,4 +28,5 @@ internal class InlayConfiguration
 	public string CustomCss = "";
 	public bool Muted;
 	public bool ActOptimizations;
+	public bool Fullscreen;
 }

--- a/Browsingway/Inlay.cs
+++ b/Browsingway/Inlay.cs
@@ -144,6 +144,22 @@ internal class Inlay : IDisposable
 		ImGui.SetNextWindowSize(new Vector2(640, 480), ImGuiCond.FirstUseEver);
 		ImGui.Begin($"{_inlayConfig.Name}###{_inlayConfig.Guid}", GetWindowFlags());
 
+		if (_inlayConfig.Fullscreen) {
+			var screen = ImGui.GetMainViewport();
+
+			// ImGui always leaves a 1px transparent border around the window, so we need to account for that.
+			var fsPos  = new Vector2(screen.WorkPos.X - 1, screen.WorkPos.Y - 1);
+			var fsSize = new Vector2(screen.Size.X + 2 - fsPos.X, screen.Size.Y + 2 - fsPos.Y);
+
+			if (ImGui.GetWindowPos() != fsPos) {
+				ImGui.SetWindowPos(fsPos, ImGuiCond.Always);
+			}
+
+			if (_size.X != fsSize.X || _size.Y != fsSize.Y) {
+				ImGui.SetWindowSize(fsSize, ImGuiCond.Always);
+			}
+		}
+
 		HandleWindowSize();
 
 		// TODO: Browsingway.Renderer can take some time to spin up properly, should add a loading state.
@@ -176,8 +192,8 @@ internal class Inlay : IDisposable
 		                         | ImGuiWindowFlags.NoBringToFrontOnFocus
 		                         | ImGuiWindowFlags.NoFocusOnAppearing;
 
-		// ClickThrough is implicitly locked
-		bool locked = _inlayConfig.Locked || _inlayConfig.ClickThrough;
+		// ClickThrough / fullscreen is implicitly locked
+		bool locked = _inlayConfig.Locked || _inlayConfig.ClickThrough || _inlayConfig.Fullscreen;
 
 		if (locked)
 		{

--- a/Browsingway/Settings.cs
+++ b/Browsingway/Settings.cs
@@ -111,6 +111,9 @@ internal class Settings : IDisposable
 			case "typethrough":
 				CommandSettingBoolean(args[2], ref targetConfig.TypeThrough);
 				break;
+			case "fullscreen":
+				CommandSettingBoolean(args[2], ref targetConfig.Fullscreen);
+				break;
 			case "clickthrough":
 				CommandSettingBoolean(args[2], ref targetConfig.ClickThrough);
 				break;
@@ -129,7 +132,7 @@ internal class Settings : IDisposable
 
 			default:
 				Chat.PrintError(
-					$"Unknown setting '{args[1]}. Valid settings are: url,hidden,locked,clickthrough,typethrough,muted,disabled,act.");
+					$"Unknown setting '{args[1]}. Valid settings are: url,hidden,locked,fullscreen,clickthrough,typethrough,muted,disabled,act.");
 				return;
 		}
 
@@ -381,6 +384,7 @@ internal class Settings : IDisposable
 				"\t\thidden: boolean\n" +
 				"\t\ttypethrough: boolean\n" +
 				"\t\tclickthrough: boolean\n" +
+				"\t\tfullscreen: boolean\n" +
 				"\t\treload: -\n" +
 				"\tvalue: Value to set for the setting. Accepted values are:\n" +
 				"\t\tstring: any string value\n\t\tboolean: on, off, toggle");
@@ -517,7 +521,7 @@ internal class Settings : IDisposable
 
 		ImGui.NextColumn();
 		ImGui.NextColumn();
-
+		
 		if (ImGui.Checkbox("ACT/IINACT optimizations", ref inlayConfig.ActOptimizations))
 		{
 			if (!inlayConfig.Disabled)
@@ -543,13 +547,20 @@ internal class Settings : IDisposable
 		ImGui.NextColumn();
 		ImGui.NextColumn();
 
-		if (inlayConfig.ClickThrough) { ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f); }
+		dirty |= ImGui.Checkbox("Fullscreen", ref inlayConfig.Fullscreen);
+		if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Automatically makes this inlay cover the entire screen when enabled."); }
+
+		ImGui.NextColumn();
+		ImGui.NextColumn();
+
+		if (inlayConfig.ClickThrough || inlayConfig.Fullscreen) { ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f); }
 
 		bool true_ = true;
-		dirty |= ImGui.Checkbox("Locked", ref inlayConfig.ClickThrough ? ref true_ : ref inlayConfig.Locked);
+		bool implicit_ = inlayConfig.ClickThrough || inlayConfig.Fullscreen;
+		dirty |= ImGui.Checkbox("Locked", ref implicit_ ? ref true_ : ref inlayConfig.Locked);
 		if (inlayConfig.ClickThrough) { ImGui.PopStyleVar(); }
 
-		if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Prevent the inlay from being resized or moved. This is implicitly set by Click Through."); }
+		if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Prevent the inlay from being resized or moved. This is implicitly set by Click Through and Fullscreen."); }
 
 		ImGui.NextColumn();
 
@@ -561,7 +572,7 @@ internal class Settings : IDisposable
 		if (inlayConfig.ClickThrough) { ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f); }
 
 		dirty |= ImGui.Checkbox("Type Through", ref inlayConfig.ClickThrough ? ref true_ : ref inlayConfig.TypeThrough);
-		if (inlayConfig.ClickThrough) { ImGui.PopStyleVar(); }
+		if (inlayConfig.ClickThrough || inlayConfig.Fullscreen) { ImGui.PopStyleVar(); }
 
 		if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Prevent the inlay from intercepting any keyboard events. Implicitly set by Click Through."); }
 


### PR DESCRIPTION
I've added a "Fullscreen" option to inlays. I'm building a web-based overlay that contains its own "widget"/"window" system that runs on the entire screen. So instead of fiddling with pixel-perfect positioning and resizing to make an inlay cover the entire screen, this options simply fills the entire ImGui workspace to cover the screen.

"Fullscreen" implicitly enables "Locked", similarly to what "Click Through" does. It also uses the working position of ImGui, so if the dalamud dev bar (`/xldev`) is visible, inlays won't render behind it, but below it.

![image](https://github.com/Styr1x/Browsingway/assets/567518/c5f44673-ea7b-4af4-9904-fb87657aa437)

I've also fixed a small bug in the `TextureRenderHandler` that occasionally spammed the dev log window with an Index out of Bounds message during startup of the plugin / loading of an inlay.

