### PR TITLE
Add option to hide overlay when out of combat

### DIFF
--- a/Browsingway/Configuration.cs
+++ b/Browsingway/Configuration.cs
@@ -29,4 +29,6 @@ internal class InlayConfiguration
 	public bool Muted;
 	public bool ActOptimizations;
 	public bool Fullscreen;
+	public bool DisableOutOfCombat;
+	public int CombatDelay = 0;
 }

--- a/Browsingway/Plugin.cs
+++ b/Browsingway/Plugin.cs
@@ -58,6 +58,9 @@ public class Plugin : IDalamudPlugin
 	[PluginService]
 	// ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
 	private static IPluginLog PluginLog { get; set; } = null!;
+
+	[PluginService]
+	private static IClientState ClientState { get; set; } = null!;
 	
 	[PluginService]
 	// ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
@@ -140,7 +143,7 @@ public class Plugin : IDalamudPlugin
 			return;
 		}
 
-		Inlay inlay = new(_renderProcess, _settings.Config, inlayConfig, PluginLog);
+		Inlay inlay = new(_renderProcess, _settings.Config, inlayConfig, PluginLog, ClientState);
 		_inlays.Add(inlayConfig.Guid, inlay);
 	}
 

--- a/Browsingway/Settings.cs
+++ b/Browsingway/Settings.cs
@@ -520,6 +520,9 @@ internal class Settings : IDisposable
 		if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Enables or disables audio playback."); }
 
 		ImGui.NextColumn();
+		dirty |= ImGui.InputInt("Delay", ref inlayConfig.CombatDelay);
+		if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Delay to hide overlay when out-of-combat in seconds."); }
+
 		ImGui.NextColumn();
 		
 		if (ImGui.Checkbox("ACT/IINACT optimizations", ref inlayConfig.ActOptimizations))
@@ -542,9 +545,13 @@ internal class Settings : IDisposable
 			dirty = true;
 		}
 
-		if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Enables ACT/IINACT specific optimizations. This will automatically disable the overlay if ACT/IINACT is not running."); }
+		if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Enables ACT/IINACT specific optimizations. This will automatically disable the overlay if ACT/IINACT is not running.\n\nNOTE: This does NOT disable the overlay if the websocket is not reporting data."); }
 
 		ImGui.NextColumn();
+
+		dirty |= ImGui.Checkbox("Disable out of combat", ref inlayConfig.DisableOutOfCombat);
+		if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Disable this overlay when out-of-combat."); }
+
 		ImGui.NextColumn();
 		
 		if (inlayConfig.ClickThrough || inlayConfig.Fullscreen) { ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f); }


### PR DESCRIPTION
This adds an option to hide an overlay when out of combat with an optional delay.

I think it may partially address these issues:
#11 
#41 

I'll admit the UI isn't the greatest, but this gets me to where I want to be for my personal use.

Thanks for the work you did!