### PR TITLE
Implement hiding overlay in PvP areas

### DIFF
--- a/Browsingway/Configuration.cs
+++ b/Browsingway/Configuration.cs
@@ -29,5 +29,6 @@ internal class InlayConfiguration
 	public bool ActOptimizations;
 	public bool Fullscreen;
 	public bool HideOutOfCombat;
+	public bool HideInPvP;
 	public int HideDelay = 0;
 }

--- a/Browsingway/Overlay.cs
+++ b/Browsingway/Overlay.cs
@@ -107,7 +107,8 @@ internal class Overlay : IDisposable
 
 	public void Render()
 	{
-		if (_overlayConfig.Hidden || _overlayConfig.Disabled || HiddenByCombatFlags())
+		if (_overlayConfig.Hidden || _overlayConfig.Disabled || HiddenByCombatFlags() ||
+			(_overlayConfig.HideInPvP && Services.ClientState.IsPvP))
 		{
 			_mouseInWindow = false;
 			return;

--- a/Browsingway/Settings.cs
+++ b/Browsingway/Settings.cs
@@ -508,6 +508,10 @@ internal class Settings : IDisposable
 		if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Hide this overlay when out-of-combat."); }
 
 		ImGui.NextColumn();
+
+		dirty |= ImGui.Checkbox("Hide in PvP", ref overlayConfig.HideInPvP);
+		if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Hide this overlay when in a PvP area."); }
+
 		ImGui.NextColumn();
 
 		if (!overlayConfig.HideOutOfCombat) { ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f); }


### PR DESCRIPTION
* Added `HideInPvP` setting with appropriate tooltip
* Implemented hiding overlay when `ClientState.IsPvP` is `true`