### PR TITLE
bump notes on linux to use version 10.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You might also want to enable 'ACT optimizations' inside Browsingway for the spe
 
 Using Browsingway in Linux is experimental and *not supported*. However, you may have some success if you try the following steps:
 
-- Download the .NET Framework for Windows (not a typo) version 9.0.3, both [x64](https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.3/dotnet-runtime-9.0.3-win-x64.exe) and [x86](https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.3/dotnet-runtime-9.0.3-win-x86.exe) versions.
+- Download the .NET Framework for Windows (not a typo) version 10.0.1, both [x64](https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.1/dotnet-runtime-10.0.1-win-x64.exe) and [x86](https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.1/dotnet-runtime-10.0.1-win-x86.exe) versions.
 - In XIVLauncher's settings, navigate to the `Wine` tab, then click `Open Wine explorer (run apps in prefix)`.
 - In the new window, find the two .NET installers you downloaded, and run them, leaving everything set to defaults. (You can also run the installers from the command line if you prefer, but make sure to set `WINEPREFIX=~/.xlcore/wineprefix` and use the Wine executable in `~/xlcore/compatibilitytool/wine/` that matches what you're trying to use with FFXIV.
 


### PR DESCRIPTION
Hey, I've been using Browingway on Linux (its working very well so far), but the recent update broke completely.
After crawling the release notes on tag 1.7.0 I noticed that CEF was bumped to 143 and that included an C# API bump to v14.
The C# version included in Browsingway (9.0.3) is not sufficient resulting in this error log

```
2025-12-22 01:18:36.712 +01:00 [ERR] [Browsingway] [Render]: App: Z:\home\<user>\.xlcore\installedPlugins\Browsingway\1.7.0\renderer\Browsingway.Renderer.exe
2025-12-22 01:18:36.713 +01:00 [ERR] [Browsingway] [Render]: Architecture: x64
2025-12-22 01:18:36.715 +01:00 [ERR] [Browsingway] [Render]: Framework: 'Microsoft.NETCore.App', version '10.0.0' (x64)
2025-12-22 01:18:36.717 +01:00 [ERR] [Browsingway] [Render]: .NET location: C:\Program Files\dotnet\
2025-12-22 01:18:36.717 +01:00 [ERR] [Browsingway] [Render]:
2025-12-22 01:18:36.719 +01:00 [ERR] [Browsingway] [Render]: The following frameworks were found:
2025-12-22 01:18:36.722 +01:00 [ERR] [Browsingway] [Render]:   9.0.3 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
2025-12-22 01:18:36.725 +01:00 [ERR] [Browsingway] [Render]:   9.0.11 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
2025-12-22 01:18:36.725 +01:00 [ERR] [Browsingway] [Render]:
2025-12-22 01:18:36.726 +01:00 [ERR] [Browsingway] [Render]: Learn more:
2025-12-22 01:18:36.728 +01:00 [ERR] [Browsingway] [Render]: https://aka.ms/dotnet/app-launch-failed
2025-12-22 01:18:36.728 +01:00 [ERR] [Browsingway] [Render]:
2025-12-22 01:18:36.730 +01:00 [ERR] [Browsingway] [Render]: To install missing framework, download:
2025-12-22 01:18:36.735 +01:00 [ERR] [Browsingway] [Render]: https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=10.0.0&arch=x64&rid=win-x64&os=win10
2025-12-22 01:18:36.735 +01:00 [INF] [Browsingway] [Render]:
2025-12-22 01:18:36.735 +01:00 [ERR] [Browsingway] [Render]:
2025-12-22 01:18:38.329 +01:00 [ERR] [Browsingway] Render process is crashing in a loop - please check the logs. No further restarts will be attempted until Browsingway is restarted.
``` 

as the error states the version needs to be bumped to version 10 to work on linux (and probably on windows too?)